### PR TITLE
Updated seconds left label

### DIFF
--- a/RehabMe/CircularProgress/CircularProgressTimer.m
+++ b/RehabMe/CircularProgress/CircularProgressTimer.m
@@ -105,6 +105,11 @@
         minutesTextLabel = @"minute";
     }
     
+    // Singular only for "1 second"
+    if (_secondsLeft > 0 && _secondsLeft < 2) {
+        minutesTextLabel = @"second";
+    }
+    
     [minutesLabel setText:minutesTextLabel];
     [minutesLabel setTextAlignment:NSTextAlignmentCenter];
     [self addSubview:minutesLabel];


### PR DESCRIPTION
Added a change to singular display of minutes/seconds to display the text for "1 second" instead of "1 seconds"
